### PR TITLE
chore: Upgrade console_log to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 axum = { version = "0.6.4", optional = true }
 console_error_panic_hook = "0.1"
-console_log = "0.2"
+console_log = "1"
 cfg-if = "1"
 leptos = { version = "0.2", default-features = false, features = ["serde"] }
 leptos_axum = { version = "0.2", optional = true }


### PR DESCRIPTION
Following from https://github.com/leptos-rs/leptos/pull/724