### PR TITLE
Fixed lack of cargo-generate placeholders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "start-axum"
+name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
 
@@ -49,7 +49,7 @@ panic = "abort"
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
-output-name = "start-axum"
+output-name = "{{project-name}}"
 
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo leptos new --git leptos-rs/start-axum
 to generate a new project template.
 
 ```bash
-cd {projectname}
+cd {{project-name}}
 ```
 
 to go to your newly created project.  

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ After running a `cargo leptos build --release` the minimum files needed are:
 
 Copy these files to your remote server. The directory structure should be:
 ```text
-start-axum
+{{project-name}}
 site/
 ```
 Set the following environment variables (updating for your project as needed):
 ```text
-LEPTOS_OUTPUT_NAME="start-axum"
+LEPTOS_OUTPUT_NAME="{{project-name}}"
 LEPTOS_SITE_ROOT="site"
 LEPTOS_SITE_PKG_DIR="pkg"
 LEPTOS_SITE_ADDR="127.0.0.1:3000"

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 
         // injects a stylesheet into the document <head>
         // id=leptos means cargo-leptos will hot-reload this stylesheet
-        <Stylesheet id="leptos" href="/pkg/start-axum.css"/>
+        <Stylesheet id="leptos" href="/pkg/{{project-name}}.css"/>
 
         // sets the document title
         <Title text="Welcome to Leptos"/>

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ async fn main() {
     use axum::{routing::post, Router};
     use leptos::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
-    use start_axum::app::*;
-    use start_axum::fileserv::file_and_error_handler;
+    use {{crate_name}}::app::*;
+    use {{crate_name}}::fileserv::file_and_error_handler;
 
     simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 


### PR DESCRIPTION
When I tried to use this template, which, according to the docs, works with [cargo-generate](https://cargo-generate.github.io/cargo-generate/index.html), I encountered some unexpected errors regarding the name of the project.

As per [cargo-generate documentateion](https://cargo-generate.github.io/cargo-generate/templates/builtin_placeholders.html), I have added the appropriate placeholders for project-name and crate_name.