### PR TITLE
Deprecate `simple_logger` in favor of `tracing_subscriber`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ leptos_axum = { version = "0.5", optional = true }
 leptos_meta = { version = "0.5", features = ["nightly"] }
 leptos_router = { version = "0.5", features = ["nightly"] }
 log = "0.4"
-simple_logger = "4"
 tokio = { version = "1.25.0", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 wasm-bindgen = "=0.2.87"
 thiserror = "1.0.38"
 tracing = { version = "0.1.37", optional = true }
+tracing-subscriber = { version = "0.3.17", optional = true }
 http = "0.2.8"
 
 [features]
@@ -37,6 +37,7 @@ ssr = [
     "leptos_meta/ssr",
     "leptos_router/ssr",
     "dep:tracing",
+    "dep:tracing-subscriber",
 ]
 
 # Defines a size-optimized profile for the WASM bundle in release mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ async fn main() {
     use {{crate_name}}::app::*;
     use {{crate_name}}::fileserv::file_and_error_handler;
 
-    simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
 
     // Setting get_configuration(None) means we'll be using cargo-leptos's env values
     // For deployment these variables are:


### PR DESCRIPTION
This might be more of personal preference, but it's a change I always end up doing anyways.

Using `tracing_subscriber` makes it possible to easily tap into its [massive ecosystem](https://crates.io/crates/tracing#ecosystem) and use nifty features such as the built-in [`env_filter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).

