### PR TITLE
Bump `wasm-bingen` to `0.2.88`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ simple_logger = "4"
 tokio = { version = "1.25.0", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
-wasm-bindgen = "=0.2.87"
+wasm-bindgen = "=0.2.88"
 thiserror = "1.0.38"
 tracing = { version = "0.1.37", optional = true }
 http = "0.2.8"


### PR DESCRIPTION
New release as of yesterday: https://github.com/rustwasm/wasm-bindgen/releases/tag/0.2.88