### PR TITLE
Serve compressed assets by default

### DIFF
--- a/src/fileserv.rs
+++ b/src/fileserv.rs
@@ -1,42 +1,52 @@
+use crate::app::App;
+use axum::response::Response as AxumResponse;
 use axum::{
     body::Body,
     extract::State,
+    http::{Request, Response, StatusCode},
     response::IntoResponse,
-    http::{Request, Response, StatusCode, Uri},
 };
-use axum::response::Response as AxumResponse;
+use leptos::*;
 use tower::ServiceExt;
 use tower_http::services::ServeDir;
-use leptos::*;
-use crate::app::App;
 
-pub async fn file_and_error_handler(uri: Uri, State(options): State<LeptosOptions>, req: Request<Body>) -> AxumResponse {
+pub async fn file_and_error_handler(
+    State(options): State<LeptosOptions>,
+    req: Request<Body>,
+) -> AxumResponse {
     let root = options.site_root.clone();
-    let res = get_static_file(uri.clone(), &root).await.unwrap();
+    let (parts, body) = req.into_parts();
+
+    let res = get_static_file(Request::from_parts(parts.clone(), ()), &root)
+        .await
+        .unwrap();
 
     if res.status() == StatusCode::OK {
         res.into_response()
     } else {
         let handler = leptos_axum::render_app_to_stream(options.to_owned(), App);
-        handler(req).await.into_response()
+        handler(Request::from_parts(parts, body))
+            .await
+            .into_response()
     }
 }
 
 async fn get_static_file(
-    uri: Uri,
+    request: Request<()>,
     root: &str,
 ) -> Result<Response<Body>, (StatusCode, String)> {
-    let req = Request::builder()
-        .uri(uri.clone())
-        .body(Body::empty())
-        .unwrap();
     // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
     // This path is relative to the cargo root
-    match ServeDir::new(root).oneshot(req).await {
+    match ServeDir::new(root)
+        .precompressed_gzip()
+        .precompressed_br()
+        .oneshot(request)
+        .await
+    {
         Ok(res) => Ok(res.into_response()),
         Err(err) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Something went wrong: {err}"),
+            format!("Error serving files: {err}"),
         )),
     }
 }


### PR DESCRIPTION
This PR adjusts the file-serving code to serve compressed assets, if present. If static assets are not compressed, the behavior should remain unchanged.

Since the `--precompress` option in `cargo-leptos` is such a great and convenient feature, I thought it would be nice to make it easy to get working with this starter template!

One potential downside of this addition is that subsequent recompiles without `--precompress` may not be served correctly, as the file server will prefer the compressed files. I deemed this acceptable since files are not compressed by default.

Sorry for the messy diff! It looks like the file wasn't previously run through `rustfmt`. I should also note that I made an opinionated change to the error message, but I thought it would make an actual panic a little more clear.