### PR TITLE
Add a "nightly" option to the project generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 axum = { version = "0.7", optional = true }
 console_error_panic_hook = "0.1"
-leptos = { version = "0.6", features = ["nightly"] }
+leptos = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 leptos_axum = { version = "0.6", optional = true }
-leptos_meta = { version = "0.6", features = ["nightly"] }
-leptos_router = { version = "0.6", features = ["nightly"] }
+leptos_meta = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_router = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,5 @@
+[placeholders]
+nightly = { prompt = "Use nightly features?", choices = ["No", "Yes"], default = "No", type = "string"}
+
+[conditional.'nightly == "No"']
+ignore = ["rust-toolchain.toml"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,6 +45,6 @@ fn HomePage() -> impl IntoView {
 
     view! {
         <h1>"Welcome to Leptos!"</h1>
-        <button on:click=on_click>"Click Me: " {count}</button>
+        <button on:click=on_click>"Click Me: " { {%- if nightly == "Yes" -%} count {%- else -%} move || count.get() {%- endif -%} }</button>
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,6 +45,6 @@ fn HomePage() -> impl IntoView {
 
     view! {
         <h1>"Welcome to Leptos!"</h1>
-        <button on:click=on_click>"Click Me: " { {%- if nightly == "Yes" -%} count {%- else -%} move || count.get() {%- endif -%} }</button>
+        <button on:click=on_click>"Click Me: " {count}</button>
     }
 }


### PR DESCRIPTION
Since the examples are getting moved towards the stable feature set, I thought it might be nice to give the user the option to choose between "stable" and "nightly" when creating a new project with the official starter templates.

With this change the user will now be prompted during project generation if the nightly features should be enabled.

I hope I didn't forget anything. I only tried a quick `cargo leptos watch` and didn't see any issues.

I would also be willing to implement the same change for the other 2 starters if  it seems useful.